### PR TITLE
Changed the condition so it is evaluated against the service type properties

### DIFF
--- a/charts/kubevirt-vm/templates/service.yaml
+++ b/charts/kubevirt-vm/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
       port: {{ $value.port }}
       targetPort: {{ $value.targetPort }}
       protocol: {{ $value.protocol }}
-      {{- if eq $value.type "NodePort" }}
+      {{- if eq $props.type "NodePort" }}
       nodePort: {{ $value.nodePort }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
Hello, 

There was a problem with [this condition](https://github.com/cloudymax/kubevirt-community-stack/pull/104/files#diff-8704409b6383a0b018c95f4b4831ea97cdac13e1d68741f604c10bf327130ef3L21) where it wouldn't template in the provided nodePort in the following configuration for the service:

```yaml
        service:
        - name: test-vm
          type: NodePort
          externalTrafficPolicy: Cluster
          ports:
            - name: ssh
              nodePort: 30222
              port: 2222
              targetPort: 22
              protocol: TCP
```

Adding a `ports[*].type: NodePort` Key, value would solve the problem, but it seemed like a bug. 

So, I changed the condition to `if eq $props.type "NodePort"`. 
