### PR TITLE
bump version of cloud-init included in kubevirt-vm to 0.4.0

### DIFF
--- a/charts/kubevirt-vm/Chart.lock
+++ b/charts/kubevirt-vm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cloud-init
   repository: https://cloudymax.github.io/kubevirt-community-stack
-  version: 0.3.0
-digest: sha256:f06491ebc3cb3267b4fb9056f337af4405aadb1e3e4dde64817e2b8c0ef09c3b
-generated: "2025-08-07T18:48:50.521660925Z"
+  version: 0.4.0
+digest: sha256:d67fa26bb90d70c748a9461e2c0f205f2f271962e97570ab618e814260b83122
+generated: "2025-10-06T23:04:49.454877+02:00"

--- a/charts/kubevirt-vm/Chart.yaml
+++ b/charts/kubevirt-vm/Chart.yaml
@@ -3,7 +3,7 @@ name: kubevirt-vm
 description: Configure a virtual machine for use with Kubevirt
 
 type: application
-version: 0.5.2
+version: 0.6.0
 appVersion: "0.1.0"
 
 maintainers:

--- a/charts/kubevirt-vm/Chart.yaml
+++ b/charts/kubevirt-vm/Chart.yaml
@@ -3,7 +3,7 @@ name: kubevirt-vm
 description: Configure a virtual machine for use with Kubevirt
 
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "0.1.0"
 
 maintainers:
@@ -14,6 +14,6 @@ maintainers:
 dependencies:
 - name: cloud-init
   alias: cloudinit
-  version: 0.3.0
+  version: 0.4.0
   repository: https://cloudymax.github.io/kubevirt-community-stack
   condition: cloudinit.enabled

--- a/charts/kubevirt-vm/README.md
+++ b/charts/kubevirt-vm/README.md
@@ -1,6 +1,6 @@
 # kubevirt-vm
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Configure a virtual machine for use with Kubevirt
 
@@ -20,7 +20,7 @@ Configure a virtual machine for use with Kubevirt
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cloudinit | object | `{"argocdAppName":"","boot_cmd":[],"ca_certs":[],"debug":false,"disable_root":false,"disk_setup":{},"enabled":true,"envsubst":false,"existingConfigMap":false,"extraEnvVars":[],"fs_setup":[],"hostname":"test","image":"deserializeme/kv-cloud-init:v0.0.1","mounts":[],"namespace":"kubevirt","network":{"config":"disabled"},"package_reboot_if_required":false,"package_update":true,"package_upgrade":false,"packages":[],"runcmd":[],"salt":"saltsaltlettuce","secret_name":"test-scrapmetal-user-data","serviceAccount":{"create":true,"existingServiceAccountName":"cloud-init-sa","name":"cloud-init-sa"},"staticIPs":[],"swap":{"enabled":false,"filename":"/swapfile","maxsize":"1G","size":"1G"},"users":[{"groups":"users, admin, docker, sudo, kvm","lock_passwd":false,"name":"test","password":{"random":true},"shell":"/bin/bash","ssh_authorized_keys":[],"ssh_import_id":[],"sudo":"ALL=(ALL) NOPASSWD:ALL"}],"wireguard":[],"write_files":[]}` | Enable or disable usage of cloud-init sub-chart |
+| cloudinit | object | `{"argocdAppName":"","boot_cmd":[],"ca_certs":[],"debug":false,"disable_root":false,"disk_setup":[],"enabled":true,"envsubst":false,"existingConfigMap":false,"extraEnvVars":[],"fs_setup":[],"hostname":"test","image":"deserializeme/kv-cloud-init:v0.0.1","mounts":[],"namespace":"kubevirt","network":{"config":"disabled"},"package_reboot_if_required":false,"package_update":true,"package_upgrade":false,"packages":[],"runcmd":[],"salt":"saltsaltlettuce","secret_name":"test-scrapmetal-user-data","serviceAccount":{"create":true,"existingServiceAccountName":"cloud-init-sa","name":"cloud-init-sa"},"staticIPs":[],"swap":{"enabled":false,"filename":"/swapfile","maxsize":"1G","size":"1G"},"users":[{"groups":"users, admin, docker, sudo, kvm","lock_passwd":false,"name":"test","password":{"random":true},"shell":"/bin/bash","ssh_authorized_keys":[],"ssh_import_id":[],"sudo":"ALL=(ALL) NOPASSWD:ALL"}],"wireguard":[],"write_files":[]}` | Enable or disable usage of cloud-init sub-chart |
 | cloudinit.argocdAppName | string | `""` | - ArgoCD App name for optional resource tracking |
 | cloudinit.boot_cmd | list | `[]` | Run arbitrary commands early in the boot process See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#bootcmd |
 | cloudinit.ca_certs | list | `[]` | Add CA certificates See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ca-certificates |
@@ -102,7 +102,7 @@ Configure a virtual machine for use with Kubevirt
 | virtualMachine.machine.memory.overcommit.enabled | bool | `false` | Enable memory overcommitment. Tells VM it has more RAM than requested. VMI becomes Burtable QOS class and may be preempted when node is under memory pressure. GPU passthrough and vGPU will not function with overcommit enabled. |
 | virtualMachine.machine.memory.overcommit.overhead | bool | `false` | Do not allocate hypervisor overhead memory to VM. Will work for as long as most of the VirtualMachineInstances do not request the full memory. |
 | virtualMachine.machine.pinCores | bool | `true` | Pin QEMU process threads to specific physical cores Requires `--cpu-manager-policy` enabled in kubelet |
-| virtualMachine.machine.priorityClassName | string | `"vm-standard"` | If a Pod cannot be scheduled, lower priorityClass Pods will be evicted |
+| virtualMachine.machine.priorityClassName | string | `"system-node-critical"` | If a Pod cannot be scheduled, lower priorityClass Pods will be evicted |
 | virtualMachine.machine.sockets | int | `1` | Number of simulated CPU sockets. Note: Multiple cpu-bound microbenchmarks show a significant performance advantage when using sockets instead of cores Does not work with some cpuManagerPolicy options. |
 | virtualMachine.machine.threads | int | `1` | Enable simulation of Hyperthre ading on Intel CPUs or SMT AMD CPUs. |
 | virtualMachine.machine.vCores | int | `2` | Number of Virtual cores to pass to the Guest ignored when instancetype is defined |

--- a/charts/kubevirt-vm/README.md
+++ b/charts/kubevirt-vm/README.md
@@ -102,7 +102,7 @@ Configure a virtual machine for use with Kubevirt
 | virtualMachine.machine.memory.overcommit.enabled | bool | `false` | Enable memory overcommitment. Tells VM it has more RAM than requested. VMI becomes Burtable QOS class and may be preempted when node is under memory pressure. GPU passthrough and vGPU will not function with overcommit enabled. |
 | virtualMachine.machine.memory.overcommit.overhead | bool | `false` | Do not allocate hypervisor overhead memory to VM. Will work for as long as most of the VirtualMachineInstances do not request the full memory. |
 | virtualMachine.machine.pinCores | bool | `true` | Pin QEMU process threads to specific physical cores Requires `--cpu-manager-policy` enabled in kubelet |
-| virtualMachine.machine.priorityClassName | string | `"system-node-critical"` | If a Pod cannot be scheduled, lower priorityClass Pods will be evicted |
+| virtualMachine.machine.priorityClassName | string | `"vm-standard"` | If a Pod cannot be scheduled, lower priorityClass Pods will be evicted |
 | virtualMachine.machine.sockets | int | `1` | Number of simulated CPU sockets. Note: Multiple cpu-bound microbenchmarks show a significant performance advantage when using sockets instead of cores Does not work with some cpuManagerPolicy options. |
 | virtualMachine.machine.threads | int | `1` | Enable simulation of Hyperthre ading on Intel CPUs or SMT AMD CPUs. |
 | virtualMachine.machine.vCores | int | `2` | Number of Virtual cores to pass to the Guest ignored when instancetype is defined |

--- a/charts/kubevirt-vm/README.md
+++ b/charts/kubevirt-vm/README.md
@@ -1,6 +1,6 @@
 # kubevirt-vm
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Configure a virtual machine for use with Kubevirt
 
@@ -14,13 +14,13 @@ Configure a virtual machine for use with Kubevirt
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://cloudymax.github.io/kubevirt-community-stack | cloudinit(cloud-init) | 0.3.0 |
+| https://cloudymax.github.io/kubevirt-community-stack | cloudinit(cloud-init) | 0.4.0 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cloudinit | object | `{"argocdAppName":"","boot_cmd":[],"ca_certs":[],"debug":false,"disable_root":false,"disk_setup":{},"enabled":true,"envsubst":false,"existingConfigMap":false,"extraEnvVars":[],"fs_setup":[],"hostname":"test","image":"deserializeme/kv-cloud-init:v0.0.1","mounts":[],"namespace":"kubevirt","network":{"config":"disabled"},"package_reboot_if_required":false,"package_update":true,"package_upgrade":false,"packages":[],"runcmd":[],"salt":"saltsaltlettuce","secret_name":"test-scrapmetal-user-data","serviceAccount":{"create":true,"existingServiceAccountName":"cloud-init-sa","name":"cloud-init-sa"},"swap":{"enabled":false,"filename":"/swapfile","maxsize":"1G","size":"1G"},"users":[{"groups":"users, admin, docker, sudo, kvm","lock_passwd":false,"name":"test","password":{"random":true},"shell":"/bin/bash","ssh_authorized_keys":[],"ssh_import_id":[],"sudo":"ALL=(ALL) NOPASSWD:ALL"}],"wireguard":[],"write_files":[]}` | Enable or disable usage of cloud-init sub-chart |
+| cloudinit | object | `{"argocdAppName":"","boot_cmd":[],"ca_certs":[],"debug":false,"disable_root":false,"disk_setup":{},"enabled":true,"envsubst":false,"existingConfigMap":false,"extraEnvVars":[],"fs_setup":[],"hostname":"test","image":"deserializeme/kv-cloud-init:v0.0.1","mounts":[],"namespace":"kubevirt","network":{"config":"disabled"},"package_reboot_if_required":false,"package_update":true,"package_upgrade":false,"packages":[],"runcmd":[],"salt":"saltsaltlettuce","secret_name":"test-scrapmetal-user-data","serviceAccount":{"create":true,"existingServiceAccountName":"cloud-init-sa","name":"cloud-init-sa"},"staticIPs":[],"swap":{"enabled":false,"filename":"/swapfile","maxsize":"1G","size":"1G"},"users":[{"groups":"users, admin, docker, sudo, kvm","lock_passwd":false,"name":"test","password":{"random":true},"shell":"/bin/bash","ssh_authorized_keys":[],"ssh_import_id":[],"sudo":"ALL=(ALL) NOPASSWD:ALL"}],"wireguard":[],"write_files":[]}` | Enable or disable usage of cloud-init sub-chart |
 | cloudinit.argocdAppName | string | `""` | - ArgoCD App name for optional resource tracking |
 | cloudinit.boot_cmd | list | `[]` | Run arbitrary commands early in the boot process See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#bootcmd |
 | cloudinit.ca_certs | list | `[]` | Add CA certificates See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ca-certificates |
@@ -39,6 +39,7 @@ Configure a virtual machine for use with Kubevirt
 | cloudinit.salt | string | `"saltsaltlettuce"` | salt used for password generation |
 | cloudinit.secret_name | string | `"test-scrapmetal-user-data"` | name of secret in which to save the user-data file |
 | cloudinit.serviceAccount | object | `{"create":true,"existingServiceAccountName":"cloud-init-sa","name":"cloud-init-sa"}` | Choose weather to create a service-account or not. Once a SA has been created you should set this to false on subsequent runs. |
+| cloudinit.staticIPs | list | `[]` | Add a list staatic IP address assignment via networkData. For use with Multus |
 | cloudinit.swap | object | `{"enabled":false,"filename":"/swapfile","maxsize":"1G","size":"1G"}` | creates a swap file using human-readable values. |
 | cloudinit.users | list | `[{"groups":"users, admin, docker, sudo, kvm","lock_passwd":false,"name":"test","password":{"random":true},"shell":"/bin/bash","ssh_authorized_keys":[],"ssh_import_id":[],"sudo":"ALL=(ALL) NOPASSWD:ALL"}]` | user configuration options See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups do NOT use 'admin' as username - it conflicts with multiele cloud-images |
 | cloudinit.users[0].password | object | `{"random":true}` | set user password from existing secret or generate random |

--- a/charts/kubevirt-vm/templates/virtualmachine.yaml
+++ b/charts/kubevirt-vm/templates/virtualmachine.yaml
@@ -262,6 +262,17 @@ spec:
               {{- if eq .Values.cloudinit.enabled true }}
               name: {{ .Values.cloudinit.secret_name }}
               {{- end }}
+            {{- if eq .Values.cloudinit.enabled true }}
+            {{- if .Values.cloudinit.staticIPs }}
+            networkDataSecretRef:
+              {{- if eq .Values.userDataSecret.enabled true }}
+              name: {{ .Values.userDataSecret.name }}
+              {{- else }}
+              name: {{ .Values.cloudinit.secret_name }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+
         {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kubevirt-vm/values.yaml
+++ b/charts/kubevirt-vm/values.yaml
@@ -87,7 +87,7 @@ virtualMachine:
 
   machine:
     # -- If a Pod cannot be scheduled, lower priorityClass Pods will be evicted
-    priorityClassName: vm-standard
+    priorityClassName: system-node-critical
 
     # -- Define CPU, RAM, GPU, HostDevice settings for VMs.
     # Overrides: vCores, memory, gpus
@@ -200,25 +200,25 @@ disks:
 #################################################
 # DataVolume disk with URL source example
 #################################################
- - name: harddrive
-   # -- Disk type: disk, cdrom, filesystem, or lun
-   type: disk
-   # -- Bus type: sata or virtio
-   bus: virtio
-   # -- Sets disk position in boot order, lower numbers are checked earlier
-   bootorder: 2
-   # -- Set disk to be Read-only
-   readonly: false
-   # -- Size of disk in GB
-   pvsize: 16Gi
-   # -- Storage class to use for the pvc
-   pvstorageClassName: fast-raid
-   # -- Access mode for the PVC
-   pvaccessMode: ReadWriteOnce
-   # -- source type of the disk image. One of `url`, `pvc`
-   source: url
-   # -- URL of cloud-image
-   url: "https://buildstars.online/debian-12-generic-amd64-daily.qcow2"
+  - name: harddrive
+    # -- Disk type: disk, cdrom, filesystem, or lun
+    type: disk
+    # -- Bus type: sata or virtio
+    bus: virtio
+    # -- Sets disk position in boot order, lower numbers are checked earlier
+    bootorder: 2
+    # -- Set disk to be Read-only
+    readonly: false
+    # -- Size of disk in GB
+    pvsize: 16Gi
+    # -- Storage class to use for the pvc
+    pvstorageClassName: fast-raid
+    # -- Access mode for the PVC
+    pvaccessMode: ReadWriteOnce
+    # -- source type of the disk image. One of `url`, `pvc`
+    source: url
+    # -- URL of cloud-image
+    url: "https://buildstars.online/debian-12-generic-amd64-daily.qcow2"
 
 #########################################################
 # Ephemeral disk example
@@ -382,7 +382,7 @@ cloudinit:
     size: 1G
     maxsize: 1G
 
-  disk_setup: {}
+  disk_setup: []
     # -- The name of the device.
   #  - name: /dev/vdb
   #    # -- This is a list of values, with the percentage of disk that
@@ -509,12 +509,12 @@ cloudinit:
   # -- Add a list staatic IP address assignment via networkData.
   # For use with Multus
   staticIPs: []
-  # - name: enp1s0
-  #   type: physical
-  #   subnets:
-  #   - type: static
-  #     address: 192.168.1.100/32
-  #     gateway: 192.168.1.1
+  #- name: enp1s0
+  #  type: physical
+  #  subnets:
+  #  - type: static
+  #    address: 192.168.2.111/32
+  #    gateway: 192.168.2.1
 
 ################################################################################
 # ____                  _             ___     ___

--- a/charts/kubevirt-vm/values.yaml
+++ b/charts/kubevirt-vm/values.yaml
@@ -87,7 +87,7 @@ virtualMachine:
 
   machine:
     # -- If a Pod cannot be scheduled, lower priorityClass Pods will be evicted
-    priorityClassName: system-node-critical
+    priorityClassName: vm-standard
 
     # -- Define CPU, RAM, GPU, HostDevice settings for VMs.
     # Overrides: vCores, memory, gpus

--- a/charts/kubevirt-vm/values.yaml
+++ b/charts/kubevirt-vm/values.yaml
@@ -506,6 +506,16 @@ cloudinit:
   runcmd: []
   #  - docker run -d -p 8080:80 nginx
 
+  # -- Add a list staatic IP address assignment via networkData.
+  # For use with Multus
+  staticIPs: []
+  # - name: enp1s0
+  #   type: physical
+  #   subnets:
+  #   - type: static
+  #     address: 192.168.1.100/32
+  #     gateway: 192.168.1.1
+
 ################################################################################
 # ____                  _             ___     ___
 #/ ___|  ___ _ ____   _(_) ___ ___   ( _ )   |_ _|_ __   __ _ _ __ ___  ___ ___


### PR DESCRIPTION
- bump version of cloud-init included in kubevirt-vm to 0.4.0
- cleanup default values by fixing some indent and type errors
- enable templating a networkData secret when `cloudinit.staticIPs` is set