### PR TITLE
fix typo in module name

### DIFF
--- a/charts/cloud-init/Chart.yaml
+++ b/charts/cloud-init/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: cloud-init
 description: A Helm chart that generates cloud-init config files
 type: application
-version: 0.4.0
+version: 0.4.1
 maintainers:
   - name: cloudymax

--- a/charts/cloud-init/README.md
+++ b/charts/cloud-init/README.md
@@ -1,6 +1,6 @@
 # cloud-init
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart that generates cloud-init config files
 

--- a/charts/cloud-init/templates/configmap.yaml
+++ b/charts/cloud-init/templates/configmap.yaml
@@ -63,7 +63,7 @@ data:
         {{- end }}
       {{- end }}
     {{- with .Values.boot_cmd }}
-    boot_cmd:
+    bootcmd:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if gt (len .Values.write_files) 0 }}


### PR DESCRIPTION
fix module name typo `boot_cmd` -> `bootcmd`